### PR TITLE
Fix netlify redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,2 @@
 /php-houdini-tutorial/*  https://iridescent-taffy-aa4db8.netlify.app/:splat  200
+/php-houdini /php-houdini/ 301


### PR DESCRIPTION
Looks like `/php-houdini` without the trailing slash is loading `/php-houdini.html`, which we don't want.

Try setting a redirect to see if that fixes it.